### PR TITLE
VR project splitting

### DIFF
--- a/PW27_2018_Boston/Projects/SlicerVR/README.md
+++ b/PW27_2018_Boston/Projects/SlicerVR/README.md
@@ -1,6 +1,6 @@
 Back to [Projects List](../../README.md#ProjectsList)
 
-# SlicerVR - Interacting with Slicer Scene in Virtual Reality Headsets
+# SlicerOpenVR Extension Development
 
 ## Key Investigators
 
@@ -22,8 +22,6 @@ Back to [Projects List](../../README.md#ProjectsList)
 ## Approach and Plan
 
 1. Test building and packaging. Fix all the errors.
-1. Make it more intuitive how to fly around in the scene.
-1. Make controllers change transforms (maybe determine transform automatically from the grabbed actor), so that changes are reflected in all render windows.
 1. Testing Testing Testing
 1. Have fun in VR!!!
 

--- a/PW27_2018_Boston/Projects/SlicerVRInteractions/README.md
+++ b/PW27_2018_Boston/Projects/SlicerVRInteractions/README.md
@@ -1,0 +1,48 @@
+Back to [Projects List](../../README.md#ProjectsList)
+
+# SlicerVR - Interacting with Slicer Scene in Virtual Reality Headsets
+
+## Key Investigators
+
+- Jean-Christophe Fillion-Robin (Kitware)
+- Beatriz Paniagua, and others (Kitware)
+- Mark Asselin (PerkLab)
+- Andras Lasso (PerkLab)
+- Steve Pieper (Isomics)
+- Csaba Pinter (PerkLab)
+
+# Project Description
+
+## Objective
+
+1. Agree on initial design of user interaction with Slicer through VR
+2. Potentially a working prototype showing the basic features
+
+## Approach and Plan
+
+1. Make it more intuitive how to fly around in the scene
+1. Make controllers change transforms (maybe determine transform automatically from the grabbed actor), so that changes are reflected in all render windows
+    o Constraints of motion (e.g. only along a line), with support of custom handling of transforms (when there is a more complex trajectory etc.)
+
+## Progress and Next Steps
+
+<!--Describe progress and next steps in a few bullet points as you are making progress.-->
+
+# Illustrations
+
+<!--Add pictures and links to videos that demonstrate what has been accomplished.-->
+
+![Description of picture](Example2.jpg)
+
+![Some more images](Example2.jpg)
+
+# Background and References
+
+<!--Use this space for information that may help people better understand your project, like links to papers, source code, or data.-->
+
+- Source code: https://github.com/YourUser/YourRepository
+- Documentation: https://link.to.docs
+- Test data: https://link.to.test.data
+
+<!--Link for editing page when displayed in GitHub pages-->
+<a href="{{site.github.repository_url}}/edit/master/{{page.path}}">Edit this page on GitHub</a>

--- a/PW27_2018_Boston/README.md
+++ b/PW27_2018_Boston/README.md
@@ -68,7 +68,8 @@ To import the calendar into your own Google calendar, open [https://calendar.goo
 
 ### Visualization and Interaction
 
-1. [SlicerVR Updates](Projects/SlicerVR/README.md) (JC Fillon-Robin, Beatriz Paniagua, and others)
+1. [SlicerVR Extension](Projects/SlicerVR/README.md) (JC Fillion-Robin, Beatriz Paniagua, and others)
+1. [SlicerVR Interaction Design](Projects/SlicerVRInteractions/README.md) (JC Fillion-Robin, Andras Lasso, Csaba Pinter, and others)
 1. [Medical Infrared Imaging with Slicer](Projects/MedicalInfraredImagingwithSlicer/README.md) (Jorge Quintero-Nehrkorn, Jose Carlos Ruiz-Luque, Yolanda Martin-Hernando, Juan Ruiz-Alzola)
 1. [Integration of Medical Imaging Simulators in Slicer](Projects/IntegrationOfMedicalImagingSimulatorsInSlicer/README.md) (Abián Hernández-Guedes, Jose Carlos Ruiz-Luque, Guillermo Socorro-Marrero, Juan Ruiz-Alzola)
 1. [Segment Editor VR](Projects/SegmentEditorVR/README.md) (Csaba Pinter, Andras Lasso)


### PR DESCRIPTION
Although VR is the main theme of the project week, there was a big and vague umbrella project for SlicerOpenVR that included extension build/administration things, as well as more specific interaction design. There should be more VR projects that are narrower in scope and more specific. Also, this way only those people will be involved in the specific projects who are interested in them instead of a long list of names in the umbrella project.

So I split that umbrella project to a SlicerOpenVR Extension and a SlicerOpenVR Interaction Design project.

What do you think @jcfr @lassoan @pieper @tkapur ?