### PR TITLE
Turned registration addresses into links

### DIFF
--- a/PW29_2018_London_Canada/README.md
+++ b/PW29_2018_London_Canada/README.md
@@ -11,11 +11,11 @@ To receive information about this and future events please join the [Project Wee
 
 + **Dates:** July 16-20, 2018.
 + **Location:** [Robarts Research Institute](https://www.google.ca/maps/@43.0113638,-81.2738561,3a,75y,340.63h,93.84t/data=!3m6!1e1!3m4!1sqB04BofO2fkNxgxlzynSRA!2e0!7i13312!8i6656)
-+ **REGISTRATION:** https://event-wizard.com/Slicer2018/0/register/
++ **REGISTRATION:** [https://event-wizard.com/Slicer2018/0/register/](https://event-wizard.com/Slicer2018/0/register/)
 + **Hotel:** No formal arrangement has been made, but some options are:
-  + Close, $, wide range of room styles: http://guesthouseonthemount.ca/
-  + Close, $$, balanced offering: https://windermeremanor.com/
-  + Downtown, $$/$$$, nice character, good location to explore London, http://www.deltahotellondon.com/
+  + Close, $, wide range of room styles: [http://guesthouseonthemount.ca/](http://guesthouseonthemount.ca/)
+  + Close, $$, balanced offering: [https://windermeremanor.com/](https://windermeremanor.com/)
+  + Downtown, $$/$$$, nice character, good location to explore London, [http://www.deltahotellondon.com/](http://www.deltahotellondon.com/)
 
 ## Local Organizing Committee
  


### PR DESCRIPTION
Web addresses for registration and for the accommodations were not hyperlinked. Added links.