### PR TITLE
change calendar range to PW30 date range

### DIFF
--- a/PW30_2019_GranCanaria/README.md
+++ b/PW30_2019_GranCanaria/README.md
@@ -60,7 +60,7 @@ To receive information about this and future events please join the [Project Wee
 - Conference call notes: To access these, click [here](PreparatoryMeetingsNotes.md).
 
 ## Program
-<iframe src="https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&ctz=Atlantic%2FCanary&dates=20180625%2F20180629&hours=0800%2F2000&mode=WEEK" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&ctz=Atlantic%2FCanary&dates=20190128%2F20190201&hours=0800%2F2000&mode=WEEK" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 How to add this calendar to your own?
 
 ## Projects [(How to add a new project?)](Projects/README.md)


### PR DESCRIPTION
It is confusing that it was still showing PW29, in particular since that
had the same venue, and was also at the end of a month. Although there
is some value in seeing „a typical project week schedule“, at this point
in time I think we should focus on planning and filling in the upcoming
schedule.