### PR TITLE
Add key investigators to MarkupConstraints project

### DIFF
--- a/PW37_2022_Virtual/Projects/MarkupConstraints/README.md
+++ b/PW37_2022_Virtual/Projects/MarkupConstraints/README.md
@@ -5,6 +5,10 @@ Back to [Projects List](../../README.md#ProjectsList)
 ## Key Investigators
 
 - David Allemang (Kitware Inc.)
+- Jean-Christophe Fillion-Robin (Kitware Inc.)
+- Lucia Cevidanes (University of Michigan)
+- Maxime Gillot (University of Michigan)
+- Baptiste Baquero (University of Michigan)
 
 # Project Description
 

--- a/PW37_2022_Virtual/README.md
+++ b/PW37_2022_Virtual/README.md
@@ -72,7 +72,7 @@ Adapted from https://stackoverflow.com/questions/31821974/support-user-time-zone
 
 ### Infrastructure
 * [SystoleOS: ](Projects/SystoleOS/README.md) (Rafael Palomar, Andras Lasso, Steve Pieper, Jean Christophe Fillion Robin)
-* [MarkupConstraints](Projects/MarkupConstraints/README.md) (David Allemang)
+* [MarkupConstraints](Projects/MarkupConstraints/README.md) (David Allemang, Jean-Christophe Fillion-Robin)
 
 ## Registrants
 


### PR DESCRIPTION
Added JC and the Q3DC team as key investigators for the project.

- Jean-Christophe Fillion Robin
- Lucia Cevidanes
- Maxime Gillot
- Baptiste Baquero
