### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/project-proposal.yml
@@ -1,0 +1,20 @@
+name: Project Proposal
+description: Issue template for creating an issue supporting discussion around a project concept or idea.
+title: "Proposal: "
+labels: ["proposal", "event:PW39_2023_Montreal"]
+assignees:
+  - drouin-simon
+  - piiq
+  - rafaelpalomar
+  - sjh26
+  - tkapur
+
+body:
+- type: textarea
+  attributes:
+    label: Project Description
+    description: Please provide a brief overview of the project, including the problem it aims to solve, and any expected outcomes.
+    render: markdown
+  validations:
+    required: true
+

--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -1,7 +1,7 @@
-name: Project Proposal
-description: Template to create an issue enabling discussion related to a project concept or idea
-title: "[Proposal]: "
-labels: ["proposal", "event:PW39_2023_Montreal"]
+name: Project
+description: Issue template to streamline the creation of project pages.
+title: "Project: "
+labels: ["project", "event:PW39_2023_Montreal"]
 assignees:
   - drouin-simon
   - piiq
@@ -20,7 +20,7 @@ body:
     render: markdown
   validations:
     required: true
-    
+
 - type: textarea
   attributes:
     label: Project Description


### PR DESCRIPTION
* Add a simple "project-proposal" template

* Rename "project-proposal" issue template to "project"
    
  * Change title from `[Proposal]:` to `Project:`
    
  * Change description

    ```diff
    - Template to create an issue enabling discussion related to a project concept or idea
    + Issue template to streamline the creation of project pages.
    ```
  
  * Assigned label "project" instead of "proposal"
