### PR TITLE
Generate project listing

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -10,6 +10,21 @@ assignees:
   - tkapur
 
 body:
+
+  - type: dropdown
+    attributes:
+      label: Category
+      description: Select a category that best describes your project. This will help others to quickly understand the focus of your project.
+      options:
+        - VR/AR and Rendering
+        - IGT and Training
+        - Segmentation / Classification / Landmarking
+        - Quantification and Computation
+        - Cloud / Web
+        - Infrastructure
+    validations:
+      required: true
+
 - type: textarea
   attributes:
     label: Key Investigators

--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -24,6 +24,10 @@ body:
         - Infrastructure
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        _If you are unable to find a category that is suitable for your project, or believe that a specific category is missing, please discuss it with the organizers._
 
 - type: textarea
   attributes:

--- a/PW39_2023_Montreal/Projects/Readme.md
+++ b/PW39_2023_Montreal/Projects/Readme.md
@@ -9,11 +9,8 @@
 4. Click on "Create new file" button
 5. Type `YourProjectName/README.md`
 6. Paste the previously copied content of project template page into your new `README.md`
-7. Update at least your project's __title, key investigators, project description sections__
+7. Update at least your project's __title, category, key investigators, project description sections__
 8. Create a [pull request](https://help.github.com/articles/creating-a-pull-request/) with the new page
-9. Note in the pull request which category you would like the project to be in
-10. Once the pull request is merged, @sjh26 / Sam Horvath (or similar) will add the project to the main list
-11. If you have write access to the repository and are not using a pull request, please ping @sjh26 to add the project to the main list
 
 
 [forum]: https://discourse.slicer.org/c/community/project-week

--- a/PW39_2023_Montreal/Projects/SlicerVRInteraction/Readme.md
+++ b/PW39_2023_Montreal/Projects/SlicerVRInteraction/Readme.md
@@ -2,6 +2,7 @@
 layout: pw39-project
 
 project_title: SlicerVR - Restore Interactions
+category: VR/AR and Rendering
 
 # "affiliation" and "country" are optional
 key_investigators:

--- a/PW39_2023_Montreal/Projects/Template/README.md
+++ b/PW39_2023_Montreal/Projects/Template/README.md
@@ -2,6 +2,7 @@
 layout: pw39-project
 
 project_title: Write full project title here
+category: Uncategorized
 
 key_investigators:
 - firstname: Person

--- a/PW39_2023_Montreal/Readme.md
+++ b/PW39_2023_Montreal/Readme.md
@@ -1,4 +1,14 @@
-<h2>Welcome to the web page for the 39th Project Week!</h2>
+---
+project_categories:
+- VR/AR and Rendering
+- IGT and Training
+- Segmentation / Classification / Landmarking
+- Quantification and Computation
+- Cloud / Web
+- Infrastructure
+---
+
+# Welcome to the web page for the 39th Project Week!
 
 [This event](https://projectweek.na-mic.org/PW39_2023_Montreal/) will take place June 12-16, 2023 in Montreal, Canada.
 
@@ -44,19 +54,8 @@ With the [Project Week GitHub Issue page](https://github.com/NA-MIC/ProjectWeek/
 2.    [Create a Project](https://github.com/NA-MIC/ProjectWeek/issues/new?assignees=drouin-simon%2Cpiiq%2Crafaelpalomar%2Csjh26%2Ctkapur&labels=project%2Cevent%3APW39_2023_Montreal&projects=&template=project.yml&title=Project%3A+) issue: If you are ready to create your page, you can simply create a “Project” issue. This issue will allow you to fill out a convenient form to provide the necessary details.
 
 3.    [Create the project page yourself using the template](Projects/Readme.md): If you prefer to create the Project Page yourself, you can still do so by using the provided template and submitting a pull request.
-    
-### VR/AR and Rendering
-1. [SlicerVR - Restore Interactions part 2](Projects/SlicerVRInteraction/Readme.md) (Csaba Pintér, Simon Drouin, Andrey Titov)
 
-### IGT and Training
-
-### Segmentation / Classification / Landmarking
-
-### Quantification and Computation
-
-### Cloud / Web
-
-### Infrastructure
+{% include projects.md %}
 
 ## Registrants
 

--- a/PW39_2023_Montreal/Readme.md
+++ b/PW39_2023_Montreal/Readme.md
@@ -30,22 +30,7 @@ We hold weekly preparation meetings at 10am (Eastern Time) on Tuesdays, starting
 
 ##  Agenda
 
-<div id="calendar-container">
-</div>
-
-<!--
-Adapted from https://stackoverflow.com/questions/31821974/support-user-time-zone-in-embedded-google-calendar
--->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.7/jstz.min.js" integrity="sha512-pZ0i46J1zsMwPd2NQZ4IaL427jXE2RVHMk3uv/wPTNlBVp9AbB1L65/4YdrXRPLEmyZCkY9qYOOsQp44V4orHg==" crossorigin="anonymous"></script>
-
-<script type="text/javascript">
-  var timezone = jstz.determine();
-  var iframe_src = 'https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&mode=WEEK&dates=20230612%2f20230616&ctz=' + timezone.name()
-  var iframe_html = '<iframe src="' + iframe_src + 'style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>'
-  document.getElementById('calendar-container').innerHTML = iframe_html;
-</script>
-
-[How to add this calendar to your own?](../common/Calendar.md)
+{% include calendar.md %}
 
 ## Breakout sessions
 1. [Future of rendering in VTK and Slicer](BreakoutSessions/RenderingBreakout/Readme.md)

--- a/_includes/calendar.md
+++ b/_includes/calendar.md
@@ -1,0 +1,20 @@
+<!-- Begin _includes/calendar.md -->
+
+<div id="calendar-container">
+</div>
+
+<!--
+Adapted from https://stackoverflow.com/questions/31821974/support-user-time-zone-in-embedded-google-calendar
+-->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.7/jstz.min.js" integrity="sha512-pZ0i46J1zsMwPd2NQZ4IaL427jXE2RVHMk3uv/wPTNlBVp9AbB1L65/4YdrXRPLEmyZCkY9qYOOsQp44V4orHg==" crossorigin="anonymous"></script>
+
+<script type="text/javascript">
+  var timezone = jstz.determine();
+  var iframe_src = 'https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&mode=WEEK&dates=20230612%2f20230616&ctz=' + timezone.name()
+  var iframe_html = '<iframe src="' + iframe_src + 'style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>'
+  document.getElementById('calendar-container').innerHTML = iframe_html;
+</script>
+
+[How to add this calendar to your own?](../common/Calendar.md)
+
+<!-- End _includes/calendar.md -->

--- a/_includes/project_generate_category.md
+++ b/_includes/project_generate_category.md
@@ -1,0 +1,73 @@
+<!--   _includes/project_generate_category.md
+         event_name ..........: {{ event_name }}
+         project_count .......: {{ project_count }}
+         requested_category ..: {{ requested_category }}
+-->
+
+{% for pw_page in site.pages %}
+
+  {% comment %}Extract page event name (e.g "PW39_2023_Montreal"){% endcomment %}
+  {% assign pw_page_event_name = pw_page.path | split: '/' | first %}
+
+  {% comment %}Only process page associated with the current event.{% endcomment %}
+  {% if pw_page_event_name != event_name %}
+    {% continue %}
+  {% endif %}
+
+  {% comment %}Extract page event type (e.g "Projects").{% endcomment %}
+  {% assign pw_page_type = pw_page.path | split: '/' | slice: 1 | first %}
+
+  {% comment %}Only process pages located in the "Projects" directory.{% endcomment %}
+  {% if pw_page_type != "Projects" %}
+    {% continue %}
+  {% endif %}
+
+  {% comment %}Extract page project name (e.g "SlicerVRInteraction").{% endcomment %}
+  {% assign project_name = pw_page.path | split: '/' | slice: 2 | first | downcase %}
+
+  {% comment %}Ignore "Template" and "README.md" file.{% endcomment %}
+  {% if project_name == "template" or project_name == "readme.md" %}
+    {% continue %}
+  {% endif %}
+
+  {% assign pw_page_category = pw_page.category | default:"Uncategorized" %}
+
+  {% if pw_page_category != requested_category %}
+    {% continue %}
+  {% endif %}
+
+  {% assign project_count = project_count | plus: 1 %}
+
+  {% if page.project_categories contains pw_page_category %}
+
+    {% comment %}If if applies, add catergory header.{% endcomment %}
+    {% unless categories contains pw_page_category %}
+{% capture categories %}
+{{ categories }}
+### {{ pw_page_category }}
+{% endcapture %}
+      {% endunless %}
+
+    {% comment %}Append category entry.{% endcomment %}
+{% capture categories %}
+{{ categories }}
+1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
+{%- for investigator in pw_page.key_investigators -%}
+    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+{%- endfor -%}
+)
+{% endcapture %}
+
+  {% else %}
+
+{% capture uncategorized %}
+{{ uncategorized }}
+1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
+{%- for investigator in pw_page.key_investigators -%}
+    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+{%- endfor -%}
+)
+{% endcapture %}
+
+  {% endif %}
+{% endfor %}

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -20,6 +20,8 @@ _The {{ event_name }} event has a total of {{ project_count }} projects._
 
 ### Uncategorized
 
+_This section lists projects that either have no category assigned, are assigned to the "Uncategorized" category, or are assigned to a different category than the ones listed above. If you are unable to find a category that is suitable for your project, or believe that a specific category is missing, please discuss it with the [organizers](#organizers)._
+
 {{ uncategorized }}
 
 <!-- End _includes/projects.md -->

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -1,0 +1,82 @@
+<!-- Begin _includes/projects.md -->
+
+{% comment %}Extract event name (e.g "PW39_2023_Montreal"). {% endcomment %}
+{% assign event_name = page.path | split: '/' | first %}
+
+{% assign project_count = 0 %}
+{% assign categories = "" %}
+{% assign uncategorized = "" %}
+
+{% for pw_page in site.pages %}
+
+  {% comment %}Extract page event name (e.g "PW39_2023_Montreal"){% endcomment %}
+  {% assign pw_page_event_name = pw_page.path | split: '/' | first %}
+
+  {% comment %}Only process page associated with the current event.{% endcomment %}
+  {% if pw_page_event_name != event_name %}
+    {% continue %}
+  {% endif %}
+
+  {% comment %}Extract page event type (e.g "Projects").{% endcomment %}
+  {% assign pw_page_type = pw_page.path | split: '/' | slice: 1 | first %}
+
+  {% comment %}Only process pages located in the "Projects" directory.{% endcomment %}
+  {% if pw_page_type != "Projects" %}
+    {% continue %}
+  {% endif %}
+
+  {% comment %}Extract page project name (e.g "SlicerVRInteraction").{% endcomment %}
+  {% assign project_name = pw_page.path | split: '/' | slice: 2 | first | downcase %}
+
+  {% comment %}Ignore "Template" and "README.md" file.{% endcomment %}
+  {% if project_name == "template" or project_name == "readme.md" %}
+    {% continue %}
+  {% endif %}
+
+  {% assign project_count = project_count | plus: 1 %}
+
+  {% assign pw_page_category = pw_page.category | default:"Uncategorized" %}
+
+  {% if page.project_categories contains pw_page_category %}
+
+    {% comment %}If if applies, add catergory header.{% endcomment %}
+    {% unless categories contains pw_page_category %}
+{% capture categories %}
+{{ categories }}
+### {{ pw_page_category }}
+{% endcapture %}
+      {% endunless %}
+
+    {% comment %}Append category entry.{% endcomment %}
+{% capture categories %}
+{{ categories }}
+1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
+{%- for investigator in pw_page.key_investigators -%}
+    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+{%- endfor -%}
+)
+{% endcapture %}
+
+  {% else %}
+
+{% capture uncategorized %}
+{{ uncategorized }}
+1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
+{%- for investigator in pw_page.key_investigators -%}
+    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+{%- endfor -%}
+)
+{% endcapture %}
+
+  {% endif %}
+{% endfor %}
+
+_The {{ event_name }} event has a total of {{ project_count }} projects._
+
+{{ categories }}
+
+### Uncategorized
+
+{{ uncategorized }}
+
+<!-- End _includes/projects.md -->

--- a/_includes/projects.md
+++ b/_includes/projects.md
@@ -7,69 +7,12 @@
 {% assign categories = "" %}
 {% assign uncategorized = "" %}
 
-{% for pw_page in site.pages %}
-
-  {% comment %}Extract page event name (e.g "PW39_2023_Montreal"){% endcomment %}
-  {% assign pw_page_event_name = pw_page.path | split: '/' | first %}
-
-  {% comment %}Only process page associated with the current event.{% endcomment %}
-  {% if pw_page_event_name != event_name %}
-    {% continue %}
-  {% endif %}
-
-  {% comment %}Extract page event type (e.g "Projects").{% endcomment %}
-  {% assign pw_page_type = pw_page.path | split: '/' | slice: 1 | first %}
-
-  {% comment %}Only process pages located in the "Projects" directory.{% endcomment %}
-  {% if pw_page_type != "Projects" %}
-    {% continue %}
-  {% endif %}
-
-  {% comment %}Extract page project name (e.g "SlicerVRInteraction").{% endcomment %}
-  {% assign project_name = pw_page.path | split: '/' | slice: 2 | first | downcase %}
-
-  {% comment %}Ignore "Template" and "README.md" file.{% endcomment %}
-  {% if project_name == "template" or project_name == "readme.md" %}
-    {% continue %}
-  {% endif %}
-
-  {% assign project_count = project_count | plus: 1 %}
-
-  {% assign pw_page_category = pw_page.category | default:"Uncategorized" %}
-
-  {% if page.project_categories contains pw_page_category %}
-
-    {% comment %}If if applies, add catergory header.{% endcomment %}
-    {% unless categories contains pw_page_category %}
-{% capture categories %}
-{{ categories }}
-### {{ pw_page_category }}
-{% endcapture %}
-      {% endunless %}
-
-    {% comment %}Append category entry.{% endcomment %}
-{% capture categories %}
-{{ categories }}
-1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
-{%- for investigator in pw_page.key_investigators -%}
-    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
-{%- endfor -%}
-)
-{% endcapture %}
-
-  {% else %}
-
-{% capture uncategorized %}
-{{ uncategorized }}
-1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
-{%- for investigator in pw_page.key_investigators -%}
-    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
-{%- endfor -%}
-)
-{% endcapture %}
-
-  {% endif %}
+{% for requested_category in page.project_categories %}
+{% include project_generate_category.md %}
 {% endfor %}
+
+{% assign requested_category = "Uncategorized" %}
+{% include project_generate_category.md %}
 
 _The {{ event_name }} event has a total of {{ project_count }} projects._
 


### PR DESCRIPTION
Auto-generate project listing:

* Update "project" issue template to include "Category" dropdown

* Update top-level `README` associated with the event to include the `project_categories` front-matter entry.

* Update existing project to include the "category" front-matter entry.

Additionally, it also factors out calendar into its own component


