### PR TITLE
PW39: Ensure front-matter values are escaped when needed

### DIFF
--- a/.github/workflows/project-page-pull-request.yml
+++ b/.github/workflows/project-page-pull-request.yml
@@ -123,19 +123,34 @@ jobs:
           "investigators": [.["key-investigators"].list[].text |
             capture("(?<firstname>[^,]+)(?:[[:space:]]+[[:alpha:]]+)*,[[:space:]]+(?<lastname>[^,]+(?:[[:space:]]+[[:alpha:]]+)*?) \\((?<affiliation>[^,]+)(?:, (?<country>[^)]+))?\\)") |
             {firstname, lastname, affiliation, country: (.country // "")}],
-        }' > template-data.json
+        }' > ${{ runner.temp }}/template-data.json
+
+    - name: Display template-data.json
+      run: |
+        cat ${{ runner.temp }}/template-data.json
+
+    - uses: actions/setup-python@v4.6.0
+      with:
+        python-version: "3.x"
+
+    - name: Install jinja2
+      run: |
+        python -m pip install jinja2
+
+        # Provide the cli interface
+        python -m pip install jinja2_cli
+
+        # Install the package providing the "to_yaml" and "regex_replace" filters.
+        python -m pip install jinja2-ansible-filters
 
     - name: Generate Project README.md
-      uses: cuchi/jinja2-action@v1.2.0
-      with:
-        template: ${{ steps.event_info.outputs.name }}/Projects/Template/README.md.j2
-        output_file: ${{ steps.event_info.outputs.name }}/Projects/${{ steps.project_directory.outputs.name }}/README.md
-        data_file: template-data.json
-        data_format: json
-
-    - name: Cleanup
       run: |
-        rm template-data.json
+        jinja2 \
+          ${{ steps.event_info.outputs.name }}/Projects/Template/README.md.j2 \
+          ${{ runner.temp }}/template-data.json \
+          --format json \
+          -e "jinja2_ansible_filters.AnsibleCoreFiltersExtension" \
+          -o ${{ steps.event_info.outputs.name }}/Projects/${{ steps.project_directory.outputs.name }}/README.md
 
     - uses: tibdex/github-app-token@v1
       id: generate-token

--- a/PW39_2023_Montreal/Projects/Template/README.md.j2
+++ b/PW39_2023_Montreal/Projects/Template/README.md.j2
@@ -1,16 +1,16 @@
 ---
 layout: pw39-project
 
-project_title: {{ title }}
-category: {{ category }}
+project_title: {{ title | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
+category: {{ category | regex_replace("\n$|\n\.\.\.\n$", "") }}
 
 key_investigators:
 {% for investigator in investigators %}
-- firstname: {{ investigator.firstname }}
-  lastname: {{ investigator.lastname }}
-  affiliation: {{ investigator.affiliation }}
+- firstname: {{ investigator.firstname | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
+  lastname: {{ investigator.lastname | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
+  affiliation: {{ investigator.affiliation | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
 {%- if investigator.country %}
-  country: {{ investigator.country }}
+  country: {{ investigator.country | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
 {%- endif %}
 {% endfor %}
 ---


### PR DESCRIPTION
The purpose of this commit are:

* revisits the generation of the project README to ensure the YAML values associated with the front-matter section are properly escaped.

* speed-up GitHub workflow by avoiding having to download the docker image associated with the GitHub Action `cuchi/jinja2-action`

* streamline debugging by outputting the content of `template-data.json`

* remove need for generating the `template-data.json` file in the current directory. Since no docker image is used for rendering the template, it can be used from the runner temp directory.


It is a follow-up of 66e3d34f (BUG: Remove ':' in project title)

To ensure the values are escaped, the jinja2 package is directly used. This provides more flexibility as it allows to leverage the `to_yaml` and `regex_replace` filters provided by the "jinja2-ansible-filters"[^1] package.

[^1]: https://pypi.org/project/jinja2-ansible-filters/

Note that since to_yaml is originally intended to output a complete document, we need to make sure to strip `\n` or `\n...\n` from the text as these do not make ensure in the context of a single YAML value.

For references related to the `...`, see these links:
* https://stackoverflow.com/questions/56950391/yaml-end-always-dumped-even-if-yaml-explicit-end-false
* https://stackoverflow.com/questions/66542271/what-does-three-dots-in-a-yaml-yml-mean/66542407#66542407
* https://github.com/yaml/pyyaml/issues/379
* https://github.com/ansible/ansible/issues/17095