### PR TITLE
site: Ensure ".j2" templates are not processed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,26 @@ repository: NA-MIC/ProjectWeek
 plugins:
   - jekyll-mentions
   - jemoji
+
+# Exclude from processing.
+# The following items will not be processed, by default.
+# Any item listed under the `exclude:` key here will be automatically added to
+# the internal "default list".
+#
+# Excluded items can be processed by explicitly listing the directories or
+# their entries' file path in the `include:` list.
+#
+exclude:
+  # Default
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  # This project
+  - "*.j2"


### PR DESCRIPTION
This commit fixes the following warning:

```
YAML Exception reading /github/workspace/PW39_2023_Montreal/Projects/Template/README.md.j2:
(<unknown>): did not find expected ',' or '}' while parsing a flow mapping at line 4 column 17
```