### PR TITLE
Simplify handling of investigator names

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -33,9 +33,9 @@ body:
   attributes:
     label: Key Investigators
     placeholder: |
-      - FirstName1, LastName1 (Affiliation, Country)
-      - FirstName2, LastName2 (Affiliation, Country)
-      - FirstName3, LastName3 (Affiliation, Country)
+      - FirstName1 LastName1 (Affiliation, Country)
+      - FirstName2 LastName2 (Affiliation, Country)
+      - FirstName3 LastName3 (Affiliation, Country)
   validations:
     required: true
 

--- a/.github/workflows/project-page-pull-request.yml
+++ b/.github/workflows/project-page-pull-request.yml
@@ -121,8 +121,8 @@ jobs:
           "illustrations": .illustrations.text,
           "background": .["background-and-references"].text,
           "investigators": [.["key-investigators"].list[].text |
-            capture("(?<firstname>[^,]+)(?:[[:space:]]+[[:alpha:]]+)*,[[:space:]]+(?<lastname>[^,]+(?:[[:space:]]+[[:alpha:]]+)*?) \\((?<affiliation>[^,]+)(?:, (?<country>[^)]+))?\\)") |
-            {firstname, lastname, affiliation, country: (.country // "")}],
+            capture("(?<name>[^\\s]+(?:\\s[^\\s]+)*?)\\s*\\((?<affiliation>[^,]*)(?:,\\s*(?<country>[^)]*))?\\)") |
+            {name, affiliation: (.affiliation // ""), country: (.country // "")}],
         }' > ${{ runner.temp }}/template-data.json
 
     - name: Display template-data.json

--- a/PW39_2023_Montreal/BreakoutSessions/RenderingBreakout/Readme.md
+++ b/PW39_2023_Montreal/BreakoutSessions/RenderingBreakout/Readme.md
@@ -4,43 +4,35 @@ layout: pw39-project
 project_title: The future of rendering in VTK and Slicer
 
 key_investigators:
-- firstname: Simon
-  lastname: Drouin
+- name: Simon Drouin
   affiliation: École de Technologie Supérieure
   Country: Canada
 
-- firstname: Steve
-  lastname: Piper
+- name: Steve Pieper
   affiliation: Isomics inc.
   country: USA
   
-- firstname: Murat
-  lastname: Maga
+- name: Murat Maga
   affiliation: University of Washington
   country: USA
   
-- firstname: Andras
-  lastname: Lasso
+- name: Andras Lasso
   affiliation: Queen's University
   country: Canada
   
-- firstname: Sara
-  lastname: Rolfe
+- name: Sara Rolfe
   affiliation: Seattle Children's Research Institute
   country: USA
   
-- firstname: Jean-Christophe
-  lastname: Fillion-Robin
+- name: Jean-Christophe Fillion-Robin
   affiliation: Kitware inc.
   country: USA
   
-- firstname: Stephen
-  lastname: Aylward
+- name: Stephen Aylward
   affiliation: Kitware inc.
   country: USA
   
-- firstname: Rafael
-  lastname: Palomar
+- name: Rafael Palomar
   affiliation: NTNU
   country: Norway
  

--- a/PW39_2023_Montreal/Projects/AI-EnhancedVirtualResectionsforImprovedSlicer-LiverSurgicalPlanning/README.md
+++ b/PW39_2023_Montreal/Projects/AI-EnhancedVirtualResectionsforImprovedSlicer-LiverSurgicalPlanning/README.md
@@ -5,18 +5,15 @@ project_title: AI-Enhanced Virtual Resections for Improved Slicer-Liver Surgical
 category: IGT and Training
 
 key_investigators:
-- firstname: Gabriella
-  lastname: d'Albenzio
+- name: Gabriella d'Albenzio
   affiliation: The Intevention Centre (OUS)
   country: Norway
 
-- firstname: Andras
-  lastname: Lasso
+- name: Andras Lasso
   affiliation: Queen's University
   country: Canada
   
-- firstname: Rafael
-  lastname: Palomar
+- name: Rafael Palomar
   affiliation: The Intevention Centre (OUS)
   country: Norway
 ---

--- a/PW39_2023_Montreal/Projects/ExtensionForRecurrentLungInfections/README.md
+++ b/PW39_2023_Montreal/Projects/ExtensionForRecurrentLungInfections/README.md
@@ -6,8 +6,7 @@ category: Segmentation / Classification / Landmarking
 
 key_investigators:
 
-- firstname: Pape Mady
-  lastname: Thiao
+- name: Pape Mady Thiao
   affiliation: école militaire de santé de Dakar 
   country: Sénégal
 

--- a/PW39_2023_Montreal/Projects/IntegrationOfHapticDeviceIn3DSlicerForLumbarPuncture/README.md
+++ b/PW39_2023_Montreal/Projects/IntegrationOfHapticDeviceIn3DSlicerForLumbarPuncture/README.md
@@ -6,18 +6,15 @@ category: IGT and Training
 
 key_investigators:
 
-- firstname: Pablo Sergio
-  lastname: Castellano Rodríguez
+- name: Pablo Sergio Castellano Rodríguez
   affiliation: Universidad  de Las Palmas de Gran Canaria
   country: Spain
 
-- firstname: Jose Carlos
-  lastname: Mateo Pérez
+- name: Jose Carlos Mateo Pérez
   affiliation: Universidad de Las Palmas de Gran Canaria
   country: Spain
 
-- firstname: Juan Bautista
-  lastname: Ruiz Alzola
+- name: Juan Bautista Ruiz Alzola
   affiliation: Universidad de Las Palmas de Gran Canaria
   country: Spain
 

--- a/PW39_2023_Montreal/Projects/LiveTrackedUltrasoundProcessingWithPytorch/README.md
+++ b/PW39_2023_Montreal/Projects/LiveTrackedUltrasoundProcessingWithPytorch/README.md
@@ -6,16 +6,13 @@ category: IGT and Training
 
 key_investigators:
 
-- firstname: Tamas
-  lastname: Ungi
+- name: Tamas Ungi
   affiliation: Queen's University
 
-- firstname: Colton
-  lastname: Barr
+- name: Colton Barr
   affiliation: Queen's University / BWH
 
-- firstname: Tina
-  lastname: Kapur
+- name: Tina Kapur
   affiliation: Brigham and Women's Hospital
 
 ---

--- a/PW39_2023_Montreal/Projects/MobileAugmentedRealityInteractiveNeuronavigator/README.md
+++ b/PW39_2023_Montreal/Projects/MobileAugmentedRealityInteractiveNeuronavigator/README.md
@@ -5,23 +5,19 @@ project_title: 'MARIN: Mobile Augmented Reality Interactive Neuronavigator (in S
 category: IGT and Training
 
 key_investigators:
-- firstname: Mehrdad
-  lastname: Asadi
+- name: Mehrdad Asadi
   affiliation: Concordia University
   country: Canada
   
-- firstname: Étienne
-  lastname: Léger
+- name: Étienne Léger
   affiliation: Montreal Neurological Institute
   country: Canada
   
-- firstname: Bahar
-  lastname: Jahani
+- name: Bahar Jahani
   affiliation: Concordia University
   country: Canada
 
-- firstname: Zahra
-  lastname: Asadi
+- name: Zahra Asadi
   affiliation: Concordia University
   country: Canada
 ---

--- a/PW39_2023_Montreal/Projects/MpreviewDevelopmentOfAStreamlinedSlicerModuleForManualImageAnnotation/README.md
+++ b/PW39_2023_Montreal/Projects/MpreviewDevelopmentOfAStreamlinedSlicerModuleForManualImageAnnotation/README.md
@@ -6,16 +6,13 @@ category: Cloud / Web
 
 key_investigators:
 
-- firstname: Deepa
-  lastname: Krishnaswamy
+- name: Deepa Krishnaswamy
   affiliation: BWH
 
-- firstname: Nadya
-  lastname: Shusharina
+- name: Nadya Shusharina
   affiliation: MGH
 
-- firstname: Andrey
-  lastname: Fedorov
+- name: Andrey Fedorov
   affiliation: BWH
 
 ---

--- a/PW39_2023_Montreal/Projects/RenderingSupportForMultipleViews/README.md
+++ b/PW39_2023_Montreal/Projects/RenderingSupportForMultipleViews/README.md
@@ -6,18 +6,15 @@ category: VR/AR and Rendering
 
 key_investigators:
 
-- firstname: Sara
-  lastname: Rolfe
+- name: Sara Rolfe
   affiliation: Seattle Children's Research Institute
   country: USA
 
-- firstname: Murat
-  lastname: Maga
+- name: Murat Maga
   affiliation: University of Washington
   country: USA
 
-- firstname: Chi
-  lastname: Zhang
+- name: Chi Zhang
   affiliation: Seattle Children's Research Institute
   country: USA
 

--- a/PW39_2023_Montreal/Projects/SlicerVRInteraction/Readme.md
+++ b/PW39_2023_Montreal/Projects/SlicerVRInteraction/Readme.md
@@ -4,20 +4,16 @@ layout: pw39-project
 project_title: SlicerVR - Restore Interactions
 category: VR/AR and Rendering
 
-# "affiliation" and "country" are optional
 key_investigators:
-- firstname: Csaba
-  lastname: Pintér
+- name: Csaba Pintér
   affiliation: EBATINCA
   country: Spain
 
-- firstname: Simon
-  lastname: Drouin
+- name: Simon Drouin
   affiliation: ÉTS Montréal
   country: Canada
 
-- firstname: Andrey
-  lastname: Titov
+- name: Andrey Titov
   affiliation: ÉTS Montréal
   country: Canada
 ---

--- a/PW39_2023_Montreal/Projects/Template/README.md
+++ b/PW39_2023_Montreal/Projects/Template/README.md
@@ -5,12 +5,10 @@ project_title: Write full project title here
 category: Uncategorized
 
 key_investigators:
-- firstname: Person
-  lastname: Doe
+- name: Person Doe
   affiliation: University
 
-- firstname: Person2
-  lastname: Doe2
+- name: Person2 Doe2
   affiliation: University2
   country: Spain
 ---

--- a/PW39_2023_Montreal/Projects/Template/README.md.j2
+++ b/PW39_2023_Montreal/Projects/Template/README.md.j2
@@ -6,8 +6,7 @@ category: {{ category | regex_replace("\n$|\n\.\.\.\n$", "") }}
 
 key_investigators:
 {% for investigator in investigators %}
-- firstname: {{ investigator.firstname | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
-  lastname: {{ investigator.lastname | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
+- name: {{ investigator.name | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
   affiliation: {{ investigator.affiliation | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}
 {%- if investigator.country %}
   country: {{ investigator.country | to_yaml | regex_replace("\n$|\n\.\.\.\n$", "") }}

--- a/PW39_2023_Montreal/Projects/TrackedUltrasoundIntegrationIntoNousnavALowCostNeuronavigationSystem/README.md
+++ b/PW39_2023_Montreal/Projects/TrackedUltrasoundIntegrationIntoNousnavALowCostNeuronavigationSystem/README.md
@@ -7,38 +7,31 @@ category: IGT and Training
 
 key_investigators:
 
-- firstname: Colton
-  lastname: Barr
+- name: Colton Barr
   affiliation: Queen's University / Brigham and Women's Hospital
   country: Canada
   
-- firstname: Sarah
-  lastname: Frisken
+- name: Sarah Frisken
   affiliation: Brigham and Women's Hospital
   country: USA
   
-- firstname: Sonia
-  lastname: Pujol
+- name: Sonia Pujol
   affiliation: Brigham and Women's Hospital
   country: USA
   
-- firstname: Steve
-  lastname: Pieper
+- name: Steve Pieper
   affiliation: Isomics
   country: USA
   
-- firstname: Tina
-  lastname: Kapur
+- name: Tina Kapur
   affiliation: Brigham and Women's Hospital
   country: USA
   
-- firstname: Tamas
-  lastname: Ungi
+- name: Tamas Ungi
   affiliation: Queen's University
   country: Canada
 
-- firstname: Sam
-  lastname: Horvath
+- name: Sam Horvath
   affiliation: Kitware
   country: USA
 

--- a/PW39_2023_Montreal/Projects/TrainingAiAlgorithmsOnIdcData/README.md
+++ b/PW39_2023_Montreal/Projects/TrainingAiAlgorithmsOnIdcData/README.md
@@ -6,13 +6,11 @@ category: Segmentation / Classification / Landmarking
 
 key_investigators:
 
-- firstname: Cosmin
-  lastname: Ciausu
+- name: Cosmin Ciausu
   affiliation: Brigham and Women's Hospital
   country: USA
 
-- firstname: Andrey
-  lastname: Fedorov
+- name: Andrey Fedorov
   affiliation: Brigham and Women's Hospital
   country: USA
 

--- a/_includes/project_generate_category.md
+++ b/_includes/project_generate_category.md
@@ -53,7 +53,7 @@
 {{ categories }}
 1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
 {%- for investigator in pw_page.key_investigators -%}
-    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+    {{ investigator.name }}{% unless forloop.last %}, {% endunless -%}
 {%- endfor -%}
 )
 {% endcapture %}
@@ -64,7 +64,7 @@
 {{ uncategorized }}
 1. [{{ pw_page.project_title }}]({{ pw_page.url }}) (
 {%- for investigator in pw_page.key_investigators -%}
-    {{ investigator.firstname }} {{ investigator.lastname }}{% unless forloop.last %}, {% endunless -%}
+    {{ investigator.name }}{% unless forloop.last %}, {% endunless -%}
 {%- endfor -%}
 )
 {% endcapture %}

--- a/_layouts/pw39-project.html
+++ b/_layouts/pw39-project.html
@@ -11,7 +11,7 @@ Back to <a href="../../#projects-how-to-add-a-new-project">Projects List</a>
 <ul>
 {% if page.key_investigators %}
   {% for investigator in page.key_investigators %}
-  <li>{{ investigator.firstname }} {{ investigator.lastname }} ({{ investigator.affiliation }}{% if investigator.country %}, {{ investigator.country }}{% endif %})</li>
+  <li>{{ investigator.name }} ({{ investigator.affiliation }}{% if investigator.country %}, {{ investigator.country }}{% endif %})</li>
   {% endfor %}
 {% endif %}
 </ul>


### PR DESCRIPTION
This commit revisits how investigator names are processed. Instead of attempting to parse first and last names, it treats the string of representing "FirstName LastName" as single entity.

Summary of changes:
- Update placeholder displayed in Project issue template
- Update front-matter of existing project having only the "name" key
- Update generation of project listing for the main page
- Update extraction of name, county and affiliation in GitHub workflow generating the pull-request

This is a follow-up of:
* https://github.com/NA-MIC/ProjectWeek/pull/637#issuecomment-1561979483