### PR TITLE
Fix missing nonmatching categories

### DIFF
--- a/_includes/project_generate_category.md
+++ b/_includes/project_generate_category.md
@@ -31,6 +31,11 @@
   {% endif %}
 
   {% assign pw_page_category = pw_page.category | default:"Uncategorized" %}
+  
+  {% comment %}Force all non-matching projects to Uncategorized.{% endcomment %}
+  {% unless page.project_categories contains pw_page_category %}
+    {% assign pw_page_category = "Uncategorized" %}
+  {% endunless %}
 
   {% if pw_page_category != requested_category %}
     {% continue %}
@@ -66,7 +71,7 @@
 {%- for investigator in pw_page.key_investigators -%}
     {{ investigator.name }}{% unless forloop.last %}, {% endunless -%}
 {%- endfor -%}
-)
+) (Category: {{pw_page.category}})
 {% endcapture %}
 
   {% endif %}


### PR DESCRIPTION
Due to this check: https://github.com/NA-MIC/ProjectWeek/blob/a027a3b0f8cf6979c71f89afa7a9b834c893e66d/_includes/project_generate_category.md?plain=1#L35

Projects that belong to categories that are never "requested" will not show up in the list.  Projects with user-specified non-matching categories are then excluded entirely, instead of showing up in uncategorized as intended.

This fix is to recategorize non-matching projects to "uncategorized" so that they will be "requested" with the uncategorized batch

