### PR TITLE
PW39(ShapeAXI): Fix HTML rendering of mp4 using the video tag

### DIFF
--- a/PW39_2023_Montreal/Projects/ShapeAXI/README.md
+++ b/PW39_2023_Montreal/Projects/ShapeAXI/README.md
@@ -112,7 +112,10 @@ ShapeAXI is an innovative project that focuses on advancing the field of shape a
 
 # Illustrations
 
-<video src="https://github.com/juanprietob/ProjectWeek/assets/7086191/628e640e-f42c-4ba8-9f20-d7f9129e6aeb"/>
+<video
+  controls muted
+  src="https://github.com/juanprietob/ProjectWeek/assets/7086191/628e640e-f42c-4ba8-9f20-d7f9129e6aeb"
+  style="max-height:640px; min-height: 200px"/>
 
 <!-- Add pictures and links to videos that demonstrate what has been accomplished.
 ![Description of picture](Example2.jpg)

--- a/PW39_2023_Montreal/Projects/ShapeAXI/README.md
+++ b/PW39_2023_Montreal/Projects/ShapeAXI/README.md
@@ -112,8 +112,7 @@ ShapeAXI is an innovative project that focuses on advancing the field of shape a
 
 # Illustrations
 
-
-https://github.com/juanprietob/ProjectWeek/assets/7086191/628e640e-f42c-4ba8-9f20-d7f9129e6aeb
+<video src="https://github.com/juanprietob/ProjectWeek/assets/7086191/628e640e-f42c-4ba8-9f20-d7f9129e6aeb"/>
 
 <!-- Add pictures and links to videos that demonstrate what has been accomplished.
 ![Description of picture](Example2.jpg)


### PR DESCRIPTION
This commit ensures the uploaded mp4 can be rendered in both the GitHub markdown[^1] and also the generated HTML[^2].

[^1]: https://github.blog/2021-05-13-video-uploads-available-github/
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video