### PR TITLE
PW39, PW40: Update calendar template to accept "from" and "to" parameter

### DIFF
--- a/PW39_2023_Montreal/README.md
+++ b/PW39_2023_Montreal/README.md
@@ -44,7 +44,7 @@ Venue entrance on Google Maps: [https://goo.gl/maps/xNedgMBt4C6jwiCu5](https://g
 
 ##  Agenda
 
-{% include calendar.md %}
+{% include calendar.md from="2023-06-12" to="2023-06-16" %}
 
 ## Breakout sessions
 1. [Future of rendering in VTK and Slicer](BreakoutSessions/RenderingBreakout/README.md)

--- a/PW40_2024_GranCanaria/README.md
+++ b/PW40_2024_GranCanaria/README.md
@@ -29,7 +29,7 @@ The **Discord** application is used to communicate between team members and orga
 
 ##  Agenda
 
-{% include calendar.md %}
+{% include calendar.md from="2024-01-29" to="2023-02-02" %}
 
 ## Breakout sessions
 

--- a/_includes/calendar.md
+++ b/_includes/calendar.md
@@ -1,5 +1,20 @@
 <!-- Begin _includes/calendar.md -->
 
+{% raw %}
+<!--
+This template expects the following parameters:
+* "from" formatted as ISO 8601
+* "to" formatted as ISO 8601
+
+Example:
+{% include calendar.md from="2023-06-12" to="2023-06-16" %}
+
+References:
+* https://jekyllrb.com/docs/includes/#passing-parameters-to-includes
+* https://shopify.github.io/liquid/filters/date/
+-->
+{% endraw %}
+
 <div id="calendar-container">
 </div>
 
@@ -10,7 +25,7 @@ Adapted from https://stackoverflow.com/questions/31821974/support-user-time-zone
 
 <script type="text/javascript">
   var timezone = jstz.determine();
-  var iframe_src = 'https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&mode=WEEK&dates=20230612%2f20230616&ctz=' + timezone.name()
+  var iframe_src = 'https://calendar.google.com/calendar/embed?src=kitware.com_sb07i171olac9aavh46ir495c4%40group.calendar.google.com&mode=WEEK&dates={{ include.from | date: "%Y%m%d" }}%2f{{ include.to  | date: "%Y%m%d" }}&ctz=' + timezone.name()
   var iframe_html = '<iframe src="' + iframe_src + 'style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>'
   document.getElementById('calendar-container').innerHTML = iframe_html;
 </script>


### PR DESCRIPTION
This commit is a follow-up of 6bdba256f (PW39_2023_Montreal: Factor out calendar into its own component)

Reported by @drouin-simon