### PR TITLE
PW40: Remove obsolete redirects

### DIFF
--- a/PW40_2024_GranCanaria/README.md
+++ b/PW40_2024_GranCanaria/README.md
@@ -1,8 +1,5 @@
 ---
 permalink: /:path/
-redirect_from:
-- /PW40_2024_GranCanaria/README.html
-- /PW40_2024_GranCanaria/Readme.html
 
 project_categories:
 - Early Presenter


### PR DESCRIPTION
This commit is a follow-up of f9ec82922 (Ensure all README.md are rendered as index.html & add redirects "from README.html")

Since the use of the "permalink"[^1][^2] front matter variable the page for the PW40 event is properly rendered as "index.html", this commit removes the obsolete redirects.

[^1]: https://jekyllrb.com/docs/permalinks/
[^2]: https://stackoverflow.com/questions/43889579/tell-jekyll-on-github-pages-to-convert-readme-md-to-readme-html-not-index-htm/47145320#47145320