### PR TITLE
PW42: Update frontmatter to consistently specify "country" and "affiliation"

### DIFF
--- a/PW42_2025_GranCanaria/Projects/3Dand2DRadiologyCopilotIntegrationin3DSlicer/README.md
+++ b/PW42_2025_GranCanaria/Projects/3Dand2DRadiologyCopilotIntegrationin3DSlicer/README.md
@@ -15,13 +15,13 @@ key_investigators:
   country: Canada  
 - name: Vishwesh Nath
   affiliation: NVIDIA
-  country: US
+  country: USA
 - name: Nigel Nelson
   affiliation: NVIDIA
-  country: US
+  country: USA
 - name: Sean Huver
   affiliation: NVIDIA
-  country: US
+  country: USA
 - name: Mingxin Zheng
   affiliation: NVIDIA
   country: China

--- a/PW42_2025_GranCanaria/Projects/BuildsOfSlicerForArmBasedSystemsMacAndLinux/README.md
+++ b/PW42_2025_GranCanaria/Projects/BuildsOfSlicerForArmBasedSystemsMacAndLinux/README.md
@@ -10,13 +10,13 @@ key_investigators:
   country: UK
 - name: Steve Pieper
   affiliation: Isomics
-  country: US
+  country: USA
 - name: Rafael Palomar
   affiliation: OUH
   country: Norway
 - name: Jean-Christophe Fillion-Robin
   affiliation: Kitware
-  country: US
+  country: USA
 - name: Andras Lasso
   affiliation: Queen's University
   country: CA

--- a/PW42_2025_GranCanaria/Projects/CreatingLinuxDistroAgnosticBinariesForPlastimatch/README.md
+++ b/PW42_2025_GranCanaria/Projects/CreatingLinuxDistroAgnosticBinariesForPlastimatch/README.md
@@ -13,11 +13,12 @@ key_investigators:
   country: Italy
 
 - name: Andrey Fedorov
-  affiliation: Brigham and Women's Hospital
-  country: Harvard Medical Schools, USA
+  affiliation: Brigham and Women's Hospital, Harvard Medical Schools
+  country: USA
 
 - name: Jean-Christophe Fillion-Robin
-  affiliation: Kitware Inc., US
+  affiliation: Kitware Inc.
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/JSONbasedscenefileformat/README.md
+++ b/PW42_2025_GranCanaria/Projects/JSONbasedscenefileformat/README.md
@@ -18,7 +18,7 @@ key_investigators:
 
 - name: Jean-Christophe Fillion-Robin
   affiliation: Kitware
-  country: US
+  country: USA
   
 - name: Andres Diaz-Pinto
   affiliation: NVIDIA

--- a/PW42_2025_GranCanaria/Projects/LightingProblemsWithLatestSlicervr/README.md
+++ b/PW42_2025_GranCanaria/Projects/LightingProblemsWithLatestSlicervr/README.md
@@ -13,8 +13,8 @@ key_investigators:
   country: Spain
 
 - name: Andras Lasso
-  affiliation: PerkLab
-  country: Queen's, Canada
+  affiliation: PerkLab, Queen's University
+  country: Canada
 
 - name: Matt Jolley
   affiliation: CHOP

--- a/PW42_2025_GranCanaria/Projects/MorphoDepot/README.md
+++ b/PW42_2025_GranCanaria/Projects/MorphoDepot/README.md
@@ -14,8 +14,8 @@ key_investigators:
   country: USA
 
 - name: Steve Pieper
-  affiliation: Isomics
-  country: Inc., USA
+  affiliation: Isomics Inc.
+  country: USA
 
 - name: Andrey Fedorov
   affiliation: Brigham and Women's Hospital

--- a/PW42_2025_GranCanaria/Projects/NewSlicerModuleForVisualAssessmentOfPulmonaryCongestionFromUltrasound/README.md
+++ b/PW42_2025_GranCanaria/Projects/NewSlicerModuleForVisualAssessmentOfPulmonaryCongestionFromUltrasound/README.md
@@ -9,11 +9,11 @@ category: Segmentation / Classification / Landmarking
 key_investigators:
 
 - name: Mike Jin
-  affiliation: Centaur Labs
-  country: Brigham and Women's Hospital, USA
+  affiliation: Centaur Labs, Brigham and Women's Hospital
+  country: USA
 
 - name: Tamas Ungi
-  affiliation: Queens University
+  affiliation: Queens's University
   country: Canada
 
 - name: Fahimeh Fooladgar

--- a/PW42_2025_GranCanaria/Projects/OptimizeDicomwebAccessToIdcData/README.md
+++ b/PW42_2025_GranCanaria/Projects/OptimizeDicomwebAccessToIdcData/README.md
@@ -16,8 +16,8 @@ key_investigators:
   country: USA
 
 - name: Steve Pieper
-  affiliation: Isomics
-  country: Inc., USA
+  affiliation: Isomics Inc.
+  country: USA
 
 - name: Andrey Fedorov
   affiliation: BWH

--- a/PW42_2025_GranCanaria/Projects/ProjectDicomMetadataDatabases/README.md
+++ b/PW42_2025_GranCanaria/Projects/ProjectDicomMetadataDatabases/README.md
@@ -17,8 +17,8 @@ key_investigators:
   country: USA
 
 - name: Steve Pieper
-  affiliation: Isomics
-  country: Inc., USA
+  affiliation: Isomics Inc.
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/Pyradiomics/README.md
+++ b/PW42_2025_GranCanaria/Projects/Pyradiomics/README.md
@@ -14,7 +14,7 @@ key_investigators:
   
 - name: Jean-Christophe Fillion-Robin
   affiliation: Kitware Inc.
-  country: US
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/RobustBooleanOperationsLibraryForVtkSlicer/README.md
+++ b/PW42_2025_GranCanaria/Projects/RobustBooleanOperationsLibraryForVtkSlicer/README.md
@@ -17,12 +17,12 @@ key_investigators:
   country: Canada
 
 - name: Steve Pieper
-  affiliation: Isomics
-  country: Inc., USA
+  affiliation: Isomics Inc.
+  country: USA
 
 - name: Jean-Christophe Fillion-Robin
   affiliation: Kitware Inc.
-  country: US
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/SlicerSofaIntegrationOfSofaWith3DSlicerForAdvancedMedicalSimulations/README.md
+++ b/PW42_2025_GranCanaria/Projects/SlicerSofaIntegrationOfSofaWith3DSlicerForAdvancedMedicalSimulations/README.md
@@ -18,11 +18,11 @@ key_investigators:
 
 - name: Steve Pieper
   affiliation: Isomics Inc.
-  country: US
+  country: USA
 
 - name: Jean-Christophe Fillion-Robin
   affiliation: Kitware Inc.
-  country: US
+  country: USA
 
 - name: Andras Lasso
   affiliation: Queen's University
@@ -30,7 +30,7 @@ key_investigators:
 
 - name: Sam Horvath
   affiliation: Kitware Inc
-  country: US
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/SlicersofaSlicerros2Integration/README.md
+++ b/PW42_2025_GranCanaria/Projects/SlicersofaSlicerros2Integration/README.md
@@ -22,11 +22,11 @@ key_investigators:
 
 - name: Steve Pieper
   affiliation: Isomics Inc.
-  country: US
+  country: USA
 
 - name: Junichi Tokuda
   affiliation: Brigham and Women's Hospital
-  country: US
+  country: USA
 
 - name: Laura Connolly
   affiliation: Queen's University
@@ -34,7 +34,7 @@ key_investigators:
 
 - name: Anton Deguet
   affiliation: Johns Hopkins University
-  country: US
+  country: USA
 
 ---
 

--- a/PW42_2025_GranCanaria/Projects/SpinalMusculoskeletalModuleForComputingVertebralSpecificLoading/README.md
+++ b/PW42_2025_GranCanaria/Projects/SpinalMusculoskeletalModuleForComputingVertebralSpecificLoading/README.md
@@ -9,16 +9,16 @@ category: Quantification and Computation
 key_investigators:
 
 - name: Csaba Pinter
-  affiliation: Ebatinca
-  country: S.L., Spain
+  affiliation: Ebatinca S.L.
+  country: Spain
 
 - name: Ron Alkalay
   affiliation: Beth Israel Deaconess Medical Center
-  country: US
+  country: USA
 
 - name: Dennis Anderson
   affiliation: Beth Israel Deaconess Medical Center
-  country: US
+  country: USA
 
 - name: Vy Hong
   affiliation: Technical University Munich
@@ -29,12 +29,12 @@ key_investigators:
   country: Germany
 
 - name: Steve Pieper
-  affiliation: Isomics
-  country: Inc., USA
+  affiliation: Isomics Inc.
+  country: USA
 
 - name: Andras Lasso
   affiliation: Queen’s University
-  country: Canada?
+  country: Canada
 
 - name: Ron Kikinis
   affiliation: Brigham and Women’s Hospital and Harvard Medical School


### PR DESCRIPTION
- Prefer to use "USA" instead of "US"
- Fix case where `country` and `affiliation` were tangled